### PR TITLE
include param from config to invalidate cache

### DIFF
--- a/action_helpers/actions.ts
+++ b/action_helpers/actions.ts
@@ -392,6 +392,17 @@ export async function type(text: string) {
  *   go('/start?tutorial=quickstart');
  */
 export async function go(path: string): Promise<void> {
-  log(`go(${path})`);
-  await browser.get(path, PAGE_LOAD_TIMEOUT);
+  let navigatePath = path;
+
+  // Add cache invalidation param
+  // if it's set in protractor config
+  const cacheBustingParam = browser.params.cacheBustingParam;
+  if(cacheBustingParam) {
+    const urlObject = new URL(path, 'https://dummy');
+    urlObject.searchParams.set(cacheBustingParam, Date.now().toString());
+    navigatePath =`${urlObject.pathname}${urlObject.search}`;
+  }
+
+  log(`go(${navigatePath})`);
+  await browser.get(navigatePath, PAGE_LOAD_TIMEOUT);
 }


### PR DESCRIPTION
it checks if there is a parameter for cache invalidation set in protractor config and adds it to go() function as param with value of Date.now()