### PR TITLE
Prevent to select `hidden` elements

### DIFF
--- a/action_helpers/browser_side_scripts.js
+++ b/action_helpers/browser_side_scripts.js
@@ -242,7 +242,7 @@ var browserSideFind = function(locators, opt_options) {
     // Try to auto-scroll to see an element.
     if (!candidateElements.length && options.scroll !== false) {
       var maybeDisplayed = all.filter(isMaybeDisplayed);
-      if (maybeDisplayed.length == 1 && shouldAutoScroll(maybeDisplayed[0])) {
+      if (maybeDisplayed.length === 1 && shouldAutoScroll(maybeDisplayed[0])) {
         scrollToHtmlElement(maybeDisplayed[0]);
         // Sticky headers can stack so get all active and compute total height.
         var stickyHeaders = document.querySelectorAll('[data-testing="sticky-header"]');
@@ -493,8 +493,13 @@ var browserSideFind = function(locators, opt_options) {
 
   // Checks that an element can be potentially displayed after scoll.
   var isMaybeDisplayed = function(e) {
-    return e.offsetWidth && e.offsetHeight &&
-        e.getBoundingClientRect().right > 0;
+    const computedStyles = window.getComputedStyle(e);
+    return (
+        e.offsetWidth &&
+        e.offsetHeight &&
+        e.getBoundingClientRect().right > 0 &&
+        computedStyles.visibility !== 'hidden'
+    );
   };
 
   // Checks if an element or its ancestors are disabled. Returns disabled


### PR DESCRIPTION
It can be a case when elements `visibility` is `hidden` and we should not select them before we scroll to the destination.